### PR TITLE
Updating minimal Resque version in dependency

### DIFF
--- a/lib/nagios_check_resque/version.rb
+++ b/lib/nagios_check_resque/version.rb
@@ -1,3 +1,3 @@
 module NagiosCheckResque
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/nagios_check_resque.gemspec
+++ b/nagios_check_resque.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'nagios_check', '~> 0.4.0'
-  spec.add_dependency 'resque', '~> 1.25'
+  spec.add_dependency 'resque', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/nagios_check_resque.gemspec
+++ b/nagios_check_resque.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'nagios_check', '~> 0.4.0'
-  spec.add_dependency 'resque', '~> 2'
+  spec.add_dependency 'resque', ['>= 1.25', '< 3']
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Due to new version of Redis, Resque < 2.0 raises an error using the Redis.connect method which was deleted in the last version of Redis.

Therefore it would be great to allow Resque version 2.0 as a dependency of Nagios Check Resque.

All tests passed successfully following the upgrade.